### PR TITLE
Bump minimatch to version >=3.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1819,7 +1819,7 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -1843,7 +1843,7 @@
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       },
       "engines": {
         "node": ">=10.10.0"
@@ -3843,7 +3843,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -4483,7 +4483,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -5941,7 +5941,7 @@
         "chokidar": "^3.5.2",
         "debug": "^3.2.7",
         "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "pstree.remy": "^1.1.8",
         "semver": "^5.7.1",
         "supports-color": "^5.5.0",
@@ -6369,7 +6369,7 @@
       "dependencies": {
         "@npmcli/name-from-folder": "^1.0.1",
         "glob": "^7.1.6",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "read-package-json-fast": "^2.0.1"
       },
       "engines": {
@@ -7029,7 +7029,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -7146,7 +7146,7 @@
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       },
       "engines": {
         "node": ">=10"
@@ -7346,7 +7346,7 @@
         "@npmcli/installed-package-contents": "^1.0.7",
         "binary-extensions": "^2.2.0",
         "diff": "^5.0.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "npm-package-arg": "^9.0.0",
         "pacote": "^13.0.2",
         "tar": "^6.1.0"
@@ -7537,7 +7537,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "3.0.4",
+      "version": "3.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12394,7 +12394,7 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
@@ -12414,7 +12414,7 @@
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       }
     },
     "@humanwhocodes/object-schema": {
@@ -14032,7 +14032,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -14529,7 +14529,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -15594,7 +15594,7 @@
         "chokidar": "^3.5.2",
         "debug": "^3.2.7",
         "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "pstree.remy": "^1.1.8",
         "semver": "^5.7.1",
         "supports-color": "^5.5.0",
@@ -15862,7 +15862,7 @@
           "requires": {
             "@npmcli/name-from-folder": "^1.0.1",
             "glob": "^7.1.6",
-            "minimatch": "^3.0.4",
+            "minimatch": "^3.0.5",
             "read-package-json-fast": "^2.0.1"
           }
         },
@@ -16338,7 +16338,7 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.4",
+            "minimatch": "^3.0.5",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -16420,7 +16420,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "^3.0.5"
           }
         },
         "imurmurhash": {
@@ -16562,7 +16562,7 @@
             "@npmcli/installed-package-contents": "^1.0.7",
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
-            "minimatch": "^3.0.4",
+            "minimatch": "^3.0.5",
             "npm-package-arg": "^9.0.0",
             "pacote": "^13.0.2",
             "tar": "^6.1.0"
@@ -16704,7 +16704,7 @@
           }
         },
         "minimatch": {
-          "version": "3.0.4",
+          "version": "3.0.5",
           "bundled": true,
           "dev": true,
           "requires": {


### PR DESCRIPTION
Patches RegEx DDoS vulnerability

More info:
https://security.snyk.io/package/npm/minimatch/3.0.4